### PR TITLE
ci(workflow): add auto-fix-markdown workflow

### DIFF
--- a/.github/workflows/auto-fix-md.yml
+++ b/.github/workflows/auto-fix-md.yml
@@ -1,0 +1,31 @@
+name: Auto fix Markdown
+
+on:
+  workflow_dispatch:
+
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  auto-fix-markdown:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.OKP4_TOKEN }}
+
+      - name: Lint markdown files
+        uses: avto-dev/markdown-lint@v1.5.0
+        continue-on-error: true
+        with:
+          args: "README.md"
+          fix: true
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_user_name: ${{ secrets.OKP4_BOT_GIT_COMMITTER_NAME }}
+          commit_user_email: ${{ secrets.OKP4_BOT_GIT_COMMITTER_EMAIL }}
+          commit_author: ${{ secrets.OKP4_BOT_GIT_AUTHOR_NAME }} <${{ secrets.OKP4_BOT_GIT_AUTHOR_EMAIL }}>
+          commit_message: "style: autofix markdown files"


### PR DESCRIPTION
Let @bot-anik  automatically fix basic errors on the `README.md` file (using [avto-dev/markdown-lint](https://github.com/avto-dev/markdown-lint) github action) - when possible, allowing us to be a little more permissive on the markdown lint check when reviewing PRs by "remediating" *a posteriori* on the main branch.